### PR TITLE
Update package URLs

### DIFF
--- a/script/verify-definitions
+++ b/script/verify-definitions
@@ -62,7 +62,7 @@ verify() {
   done
 }
 
-case "$1" in
+case "${1:-}" in
   '' )
     echo "COMMIT-RANGE required" >&2
     help_text >&2

--- a/share/node-build/jxcore+sm-0.3.0.0
+++ b/share/node-build/jxcore+sm-0.3.0.0
@@ -6,16 +6,5 @@ after_install_package() {
   fix_jxcore_directory_structure
 }
 
-binary debian-x86 "https://jxcore.s3.amazonaws.com/0300/jx_deb32sm.zip#6b0159e5be678c232838f6baeb16eabafa9ff9a4bdb5131ce9a744370a36a933"
-binary debian-x64 "https://jxcore.s3.amazonaws.com/0300/jx_deb64sm.zip#fd9b390bcd9a90679032709a9f5160ad740429b5e06aea88b56695721c790984"
-binary debian-arm64 "https://jxcore.s3.amazonaws.com/0300/jx_debARMsm.zip#983d9f2af729baadac1380ced7b503a5026a3d0851407ca4626ab83ec104115c"
-binary debian-armv7l "https://jxcore.s3.amazonaws.com/0300/jx_debARMsm.zip#983d9f2af729baadac1380ced7b503a5026a3d0851407ca4626ab83ec104115c"
-binary debian-mips "https://jxcore.s3.amazonaws.com/0300/jx_debMIPSsm.zip#338a77ddfff589a1af3f83914d0e0fe2bf57c89c3c8110574afacc0607fdce7e"
-binary darwin-x64 "https://jxcore.s3.amazonaws.com/0300/jx_osx64sm.zip#91d8a838879c32efafc35f0302dcaff7e23117c092f79c0db2bcc23d00adf427"
-binary redhat-x64 "https://jxcore.s3.amazonaws.com/0300/jx_rh64sm.zip#4838b1dbcbd2db0009ab0f74499af1efe0a25d373d36aaa357ab386eee3c178b"
-binary suse-x64 "https://jxcore.s3.amazonaws.com/0300/jx_suse64sm.zip#5a6cc2f6168311df740b59f49e151abca34e65de4d7f1ce0986fadc9df1e4993"
-binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0300/jx_ub32sm.zip#63965f2165154af1e6c9d9e343ac9b7a586459138ed6656313958ff3ab838e83"
-binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0300/jx_ub64sm.zip#9c30cd5dbf5afb166d06e0118536af2a49fae14f49d67adee06459934a75c934"
-
-install_package jxcore-0.3.0.0 "https://github.com/jxcore/jxcore/archive/v0.3.0.tar.gz#1e76648ecd012a2370354369f6161666763b4bc028544e9dc0cb27c035a90f24" jxcore_spidermonkey standard
+install_package jxcore-0.3.0.0 "https://github.com/jxcore/jxcore/archive/v0.3.0.tar.gz#e25371772860439ee12824cc8760ccf5f6747586bc4c6bc0ef9081eb32842e1c" jxcore_spidermonkey standard
 install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.0/npmjx300.tar.gz#cfb8b86a39b790cabb236aa5c8bde99e4c743579c2d0118468b3e86ed9ec6298" jxcore_npm

--- a/share/node-build/jxcore+sm-0.3.0.1
+++ b/share/node-build/jxcore+sm-0.3.0.1
@@ -6,18 +6,5 @@ after_install_package() {
   fix_jxcore_directory_structure
 }
 
-binary freebsd9-x64 "https://jxcore.s3.amazonaws.com/0301/jx_bsd964sm.zip#a22c1be5e9afd287aa1cec78266dd30ee3b4618a5075ce03339a1e8f2d2837c7"
-binary freebsd10-x64 "https://jxcore.s3.amazonaws.com/0301/jx_bsd1064sm.zip#f016c91edc27f8168945aa35795655a3487d8e89e01d3cecd9fb4bb59ef72a56"
-binary debian-x86 "https://jxcore.s3.amazonaws.com/0301/jx_deb32sm.zip#1be47d314ba84d34042ce07d4a22826f15bd6f2d3d4368ac0b8d47dbc926c115"
-binary debian-x64 "https://jxcore.s3.amazonaws.com/0301/jx_deb64sm.zip#7f471faaffd8b9e8e1163e75e24744569adfa156282af63f012672633e596e22"
-binary debian-arm64 "https://jxcore.s3.amazonaws.com/0301/jx_debARMsm.zip#0a62cba72690c21b7a3952834f5ce9effb3e051742ef734a49bcf05284550c62"
-binary debian-armv7l "https://jxcore.s3.amazonaws.com/0301/jx_debARMsm.zip#0a62cba72690c21b7a3952834f5ce9effb3e051742ef734a49bcf05284550c62"
-binary debian-mips "https://jxcore.s3.amazonaws.com/0301/jx_debMIPSsm.zip#cfa4223f789435c939ad508344a5662ef482a5b2368f5b08fd55f08dee71f462"
-binary darwin-x64 "https://jxcore.s3.amazonaws.com/0301/jx_osx64sm.zip#4a2aec176c76e180ae574c4cff136fb71ade3fbf22e58738115e17570ef59ae6"
-binary redhat-x64 "https://jxcore.s3.amazonaws.com/0301/jx_rh64sm.zip#2827c254ed668cca6c82e133e4b3581604d18192a6d250dc6507f24943c98dbf"
-binary suse-x64 "https://jxcore.s3.amazonaws.com/0301/jx_suse64sm.zip#f30284f909c75a6bbf4845d2df135caf46960af954853e2dab1519e0e917a805"
-binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0301/jx_ub32sm.zip#c7f76539280d5131f9d01657c6c62e6b759703e720ff51aa0aa3550265a3fec4"
-binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0301/jx_ub64sm.zip#14add2a2f0ac6909dfbcdf39301e0f779866ca2fd5cfc0c97866834f2b6a8c45"
-
-install_package jxcore-0.3.0.1 "https://github.com/jxcore/jxcore/archive/v0.3.0.1.tar.gz#fd25b575b4dd42be87f9681dbcf9812836bc6389f6d90073913092085e902a44" jxcore_spidermonkey standard
+install_package jxcore-0.3.0.1 "https://github.com/jxcore/jxcore/archive/v0.3.0.1.tar.gz#39fd70b28e85be85d621e3f770d3a0be8aa56efec6b4bac206dfc4472ce55b55" jxcore_spidermonkey standard
 install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.0.1/npmjx300.tar.gz#cfb8b86a39b790cabb236aa5c8bde99e4c743579c2d0118468b3e86ed9ec6298" jxcore_npm

--- a/share/node-build/jxcore+sm-0.3.0.2
+++ b/share/node-build/jxcore+sm-0.3.0.2
@@ -6,18 +6,5 @@ after_install_package() {
   fix_jxcore_directory_structure
 }
 
-binary freebsd9-x64 "https://jxcore.s3.amazonaws.com/0302/jx_bsd964sm.zip#b6acafa0d36cbe973450db92b50cacff8d291a3e02332d6fcb9ea772eb0c0d0c"
-binary freebsd10-x64 "https://jxcore.s3.amazonaws.com/0302/jx_bsd1064sm.zip#57ce03254d8e7ecec6b99b65f8cc1f6f827e8f66f9241b5c5475abc8fb554d72"
-binary debian-x86 "https://jxcore.s3.amazonaws.com/0302/jx_deb32sm.zip#74d931db2b06de0323799270c60da20d19e0450eb42afe3f985811c22c1d359b"
-binary debian-x64 "https://jxcore.s3.amazonaws.com/0302/jx_deb64sm.zip#8c74f3b903351c7286dba54882145036cf9665d681124ad8dd2d8c2c14880aa7"
-binary debian-arm64 "https://jxcore.s3.amazonaws.com/0302/jx_debARMsm.zip#709de7d319fe8b44decd5e76f46ce434f6f410700f6c27077ffc050a13d37786"
-binary debian-armv7l "https://jxcore.s3.amazonaws.com/0302/jx_debARMsm.zip#709de7d319fe8b44decd5e76f46ce434f6f410700f6c27077ffc050a13d37786"
-binary debian-mips "https://jxcore.s3.amazonaws.com/0302/jx_debMIPSsm.zip#00875e2f41d6fa461c41a95b88099cc43af085b1268db5b15247c91d29d67b23"
-binary darwin-x64 "https://jxcore.s3.amazonaws.com/0302/jx_osx64sm.zip#0616d37bcc4ff650829fdb91ffc131a3ec2e2f55ae3de2762e6bb42931df7bda"
-binary redhat-x64 "https://jxcore.s3.amazonaws.com/0302/jx_rh64sm.zip#00f91648377bf2e1de88eeeb19ccec7062b15133428298fb70a489cf5c78aa87"
-binary suse-x64 "https://jxcore.s3.amazonaws.com/0302/jx_suse64sm.zip#0943b465a101fb6314ebd5451bc83bb762cc7a81a21bda17483cbcea6e459d5e"
-binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0302/jx_ub32sm.zip#2d25443d6895dfd9f62eb9e281081eba6d5ba6fd239eeabd02a65137ef61dada"
-binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0302/jx_ub64sm.zip#433ac458be0ac02e1ffb6f6e1db1034f35ac746286d48a40b8b65875e211e689"
-
-install_package jxcore-0.3.0.2 "https://github.com/jxcore/jxcore/archive/v0.3.0.2.tar.gz#79baa480676ef44a93d2cf6081b4d001ecf09cb746b73143cf264e8ba8601b96" jxcore_spidermonkey standard
+install_package jxcore-0.3.0.2 "https://github.com/jxcore/jxcore/archive/v0.3.0.2.tar.gz#84341e930fb160432553c7a35227d47c147403eaec5253d3ebf65f9410b01e35" jxcore_spidermonkey standard
 install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.0.2/npmjx300.tar.gz#cfb8b86a39b790cabb236aa5c8bde99e4c743579c2d0118468b3e86ed9ec6298" jxcore_npm

--- a/share/node-build/jxcore+sm-0.3.0.3
+++ b/share/node-build/jxcore+sm-0.3.0.3
@@ -6,18 +6,5 @@ after_install_package() {
   fix_jxcore_directory_structure
 }
 
-binary freebsd9-x64 "https://jxcore.s3.amazonaws.com/0303/jx_bsd964sm.zip#2a41e33a162c601592112403c897a4bcfc9e9a545566b1a61e653db08a4fd39a"
-binary freebsd10-x64 "https://jxcore.s3.amazonaws.com/0303/jx_bsd1064sm.zip#6ab26ade58788db4080eb9725660ade83ea3fdaf849ebf8a2223669f443ee0ba"
-binary debian-x86 "https://jxcore.s3.amazonaws.com/0303/jx_deb32sm.zip#f7f685ca2cda2c5dd07faf012ae92eb679fb71c50ad62fff488966edf93c9e19"
-binary debian-x64 "https://jxcore.s3.amazonaws.com/0303/jx_deb64sm.zip#a738b88215625dcc817285ccbb9fdac2abf156b1db3798a98a121526f0b60a45"
-binary debian-arm64 "https://jxcore.s3.amazonaws.com/0303/jx_debARMsm.zip#bde829b76c060dd59f3b6e8817d48cf7a0ff528b54939269f78ed197b7fb82ff"
-binary debian-armv7l "https://jxcore.s3.amazonaws.com/0303/jx_debARMsm.zip#bde829b76c060dd59f3b6e8817d48cf7a0ff528b54939269f78ed197b7fb82ff"
-binary debian-mips "https://jxcore.s3.amazonaws.com/0303/jx_debMIPSsm.zip#627999614f8667fcb09038550bccbae0ebb381e0a2e1d9146bc9e140698d65e8"
-binary darwin-x64 "https://jxcore.s3.amazonaws.com/0303/jx_osx64sm.zip#a5c6c00ffb2a293ed4f903b27cb315a1d0428c208a74f0566b86dbdaaafc6635"
-binary redhat-x64 "https://jxcore.s3.amazonaws.com/0303/jx_rh64sm.zip#96f2de935977e5db5e9ba59bf523d62f6d5ce535e72bf4de818d531b73e95e40"
-binary suse-x64 "https://jxcore.s3.amazonaws.com/0303/jx_suse64sm.zip#90b970b82e623804b5a13ff08457aede82491ab16d9262efd09a7487a9bde3c3"
-binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0303/jx_ub32sm.zip#ade168bbeb6d16879b0284579d8fb77f78f0c6f983a2b9f18a8df324026a2f28"
-binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0303/jx_ub64sm.zip#759e82a993592e91d858feb3b0a5df70fadcf42f91a393f6e8dfec5f8fb95bfd"
-
-install_package jxcore-0.3.0.3 "https://github.com/jxcore/jxcore/archive/v0.3.0.3.tar.gz#b8e4f5c791f130fb0dd51fc0489bdadf5b4dfd2ed56e050943d3269631e1ccdc" jxcore_spidermonkey standard
+install_package jxcore-0.3.0.3 "https://github.com/jxcore/jxcore/archive/v0.3.0.3.tar.gz#74be5759ff5264746a0072642720384cace3b888997dacad867424386abdcf8e" jxcore_spidermonkey standard
 install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.0.3/npmjx303.tar.gz#f3479e698f7d9288256b944cfb14842349364575a2819bd4d635ec79924c6368" jxcore_npm

--- a/share/node-build/jxcore+sm-0.3.0.4
+++ b/share/node-build/jxcore+sm-0.3.0.4
@@ -6,18 +6,5 @@ after_install_package() {
   fix_jxcore_directory_structure
 }
 
-binary freebsd9-x64 "https://jxcore.s3.amazonaws.com/0304/jx_bsd964sm.zip#77b609c3e7b9f0bb567346e5431376822d57cab56511665d6ff2990accaa0574"
-binary freebsd10-x64 "https://jxcore.s3.amazonaws.com/0304/jx_bsd1064sm.zip#6aa1bce35ee4c2ab50d93b1751473e80fc399a57ffacba299b6bc1846718fdd5"
-binary debian-x86 "https://jxcore.s3.amazonaws.com/0304/jx_deb32sm.zip#2c42a9a03c7666f3aa75e49e40694160f094756aca38384a85350316b53ddde2"
-binary debian-x64 "https://jxcore.s3.amazonaws.com/0304/jx_deb64sm.zip#9a1efc0f1cf43cc2dcf3a62a509b52c5032210994cdfb4c3aac16d1976dcb001"
-binary debian-arm64 "https://jxcore.s3.amazonaws.com/0304/jx_debARMsm.zip#5e6d17f8ab22c7fb16fc2c0c794f5d3c1207d1cc37082b79f6dcc8de258bd73c"
-binary debian-armv7l "https://jxcore.s3.amazonaws.com/0304/jx_debARMsm.zip#5e6d17f8ab22c7fb16fc2c0c794f5d3c1207d1cc37082b79f6dcc8de258bd73c"
-binary debian-mips "https://jxcore.s3.amazonaws.com/0304/jx_debMIPSsm.zip#d4128bb9f7c3b112fbd9136ac8a2b92ffd9afa4dceeaef2ad7705ddccc4fc12f"
-binary darwin-x64 "https://jxcore.s3.amazonaws.com/0304/jx_osx64sm.zip#59921d445b8fcc853923ba704e50ef0b567fa5c4899bd8b320e9f4e2ac7b4668"
-binary redhat-x64 "https://jxcore.s3.amazonaws.com/0304/jx_rh64sm.zip#fdf8e13b87301e07bd68dd694175e6ad535ac07ab160e873558c24ac1f03ad38"
-binary suse-x64 "https://jxcore.s3.amazonaws.com/0304/jx_suse64sm.zip#ff724ecdced97cea21790463d40ba81659f71f6c05803568f98a70e387b671dc"
-binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0304/jx_ub32sm.zip#0d44fc932924e4b5e27feae5e0f795a8075627e8e418d8f5ad2c5a533defc0f2"
-binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0304/jx_ub64sm.zip#cec1b83501ebc39bc2109941bc7edb8826edda66282de6929ac3127978bd4d94"
-
-install_package jxcore-0.3.0.4 "https://github.com/jxcore/jxcore/archive/v0.3.0.4.tar.gz#84e67ee008abb6794940806ab2992536144d9e831643181ea0230f4e8f1aade7" jxcore_spidermonkey standard
+install_package jxcore-0.3.0.4 "https://github.com/jxcore/jxcore/archive/v0.3.0.4.tar.gz#44331fe17190f7035d74ef91e5b15c8e888c5ddb8005bfbb1f1ef1a5de6fd2a8" jxcore_spidermonkey standard
 install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.0.4/npmjx304.tar.gz#e12617fe36c58c59ee5d06e99f421f21b8a3215d5d780597e5218e2c6b63f17a" jxcore_npm

--- a/share/node-build/jxcore+sm-0.3.0.5
+++ b/share/node-build/jxcore+sm-0.3.0.5
@@ -6,18 +6,5 @@ after_install_package() {
   fix_jxcore_directory_structure
 }
 
-binary freebsd9-x64 "https://jxcore.s3.amazonaws.com/0305/jx_bsd964sm.zip#3b1c1df87de0fe11cafe9b77c2565d4fa495de373002fb3a4e409b8cfbf00621"
-binary freebsd10-x64 "https://jxcore.s3.amazonaws.com/0305/jx_bsd1064sm.zip#d5ca2f0f048958244650a2491e0218ffb2b57f6281633eb818dd9b38002e1f10"
-binary debian-x86 "https://jxcore.s3.amazonaws.com/0305/jx_deb32sm.zip#b0deb1f6b3cf8366a8095a5ec1ac2b2007d4f7468be9aaa9470edefb3cb10cf4"
-binary debian-x64 "https://jxcore.s3.amazonaws.com/0305/jx_deb64sm.zip#7d9842cf9b3d87a611c12f26612a0963399076d40f6b9fe5b7771dc04432dc79"
-binary debian-arm64 "https://jxcore.s3.amazonaws.com/0305/jx_debARMsm.zip#4018d442d23f1be1d5375fa4983dca0be04e95fb5568e7bd6d438839a58888b3"
-binary debian-armv7l "https://jxcore.s3.amazonaws.com/0305/jx_debARMsm.zip#4018d442d23f1be1d5375fa4983dca0be04e95fb5568e7bd6d438839a58888b3"
-binary debian-mips "https://jxcore.s3.amazonaws.com/0305/jx_debMIPSsm.zip#7518b51465626a53dc471dca558d5e1712cd1f07a2865606e0707aef5ad7db91"
-binary darwin-x64 "https://jxcore.s3.amazonaws.com/0305/jx_osx64sm.zip#3d8e2706ae9c8ad9733eaf4f445c36399368dc43e53bc86ee2d84b941e796b04"
-binary redhat-x64 "https://jxcore.s3.amazonaws.com/0305/jx_rh64sm.zip#f4801c196c29bb488ba79468701ae758373618c53496b7fd71f30e7607276fba"
-binary suse-x64 "https://jxcore.s3.amazonaws.com/0305/jx_suse64sm.zip#04c98d4da55dc93551763c05783f1131c752b7579a5ea8f2e001688cc60745ed"
-binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0305/jx_ub32sm.zip#a1b4166cf948e27120c9e3c85c5940716e7f649654343955e4ae659a58f29518"
-binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0305/jx_ub64sm.zip#d254d665b42d2b4f632c73ce6afef25d8da19846cf5a9fa4eb73be9a0f9aaaa0"
-
-install_package jxcore-0.3.0.5 "https://github.com/jxcore/jxcore/archive/v0.3.0.5.tar.gz#a7c7759f66609f32bc2aed5f3674e251d66710bb742417faf5c0059319cc00b5" jxcore_spidermonkey standard
+install_package jxcore-0.3.0.5 "https://github.com/jxcore/jxcore/archive/v0.3.0.5.tar.gz#818572e99c6b047a1bbd72889308c2e3636329f92e3107cfa7ae5499ec66e398" jxcore_spidermonkey standard
 install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.0.5/npmjx305.tar.gz#fdefdb122e6ca0ea23a11730c7e032742a86b2c7e9e46421304bc6b7ce99a7fa" jxcore_npm

--- a/share/node-build/jxcore+sm-0.3.0.6
+++ b/share/node-build/jxcore+sm-0.3.0.6
@@ -6,18 +6,5 @@ after_install_package() {
   fix_jxcore_directory_structure
 }
 
-binary freebsd9-x64 "https://jxcore.s3.amazonaws.com/0306/jx_bsd964sm.zip#913d03f2017621ed053dabc4d76ffe627970ab56c380f8e92d5ee3f5d60b6a5f"
-binary freebsd10-x64 "https://jxcore.s3.amazonaws.com/0306/jx_bsd1064sm.zip#d8b967cdebcf1cb38a03765f70be20828e03aa5a228e178153f21a4ac121001a"
-binary debian-x86 "https://jxcore.s3.amazonaws.com/0306/jx_deb32sm.zip#a1e1c68b4397dff2dc4c555357592b4ca12abde2fd75f0e3436e30302b45f7b8"
-binary debian-x64 "https://jxcore.s3.amazonaws.com/0306/jx_deb64sm.zip#b9d43cfd199add588081f8ad94ef370086be066cae3cddc1b2fc8704dcc6b600"
-binary debian-arm64 "https://jxcore.s3.amazonaws.com/0306/jx_debARMsm.zip#1455423e715660c0ba2278f812a92a69487a277de20e8135c4ec1c381086d090"
-binary debian-armv7l "https://jxcore.s3.amazonaws.com/0306/jx_debARMsm.zip#1455423e715660c0ba2278f812a92a69487a277de20e8135c4ec1c381086d090"
-binary debian-mips "https://jxcore.s3.amazonaws.com/0306/jx_debMIPSsm.zip#28a87a03d997939eed1cf528194529a2655a925bc942a4097fa9819e00639409"
-binary darwin-x64 "https://jxcore.s3.amazonaws.com/0306/jx_osx64sm.zip#28969a430cc45b32225a16d23a1d3dc0f8b273e8e3c68fbee43d2953114c3575"
-binary redhat-x64 "https://jxcore.s3.amazonaws.com/0306/jx_rh64sm.zip#77fdfaaa88ee4f75489f831a569e4a8d143b984173396e119ff0e6141af4cc97"
-binary suse-x64 "https://jxcore.s3.amazonaws.com/0306/jx_suse64sm.zip#1f6a6e519fb92981a96445481e985d9dc6ac25f9a84f038d0ba57a0b2eadbf0c"
-binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0306/jx_ub32sm.zip#c09a3e2442126c349a802c48e2a58b8e391f0355a1ad8131b492b7e2434031ae"
-binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0306/jx_ub64sm.zip#edc80a72aec681bfe2501be2fb89ae9deb7faf265cc208e3a82921a8dedcfb2a"
-
-install_package jxcore-0.3.0.6 "https://github.com/jxcore/jxcore/archive/v0.3.0.6.tar.gz#8e978743f126c27ba6478873013d71575af23082c1804f3cbaa911d720ef0f19" jxcore_spidermonkey standard
+install_package jxcore-0.3.0.6 "https://github.com/jxcore/jxcore/archive/v0.3.0.6.tar.gz#ba77e9583b6c305c20a03a3d5443a01d96b99785fbaa17b8569cf68b5be8903d" jxcore_spidermonkey standard
 install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.0.6/npmjx305.tar.gz#fdefdb122e6ca0ea23a11730c7e032742a86b2c7e9e46421304bc6b7ce99a7fa" jxcore_npm

--- a/share/node-build/jxcore+sm-0.3.0.7
+++ b/share/node-build/jxcore+sm-0.3.0.7
@@ -6,18 +6,5 @@ after_install_package() {
   fix_jxcore_directory_structure
 }
 
-binary freebsd9-x64 "https://jxcore.s3.amazonaws.com/0307/jx_bsd964sm.zip#ffb33292c31304a87655647c120486507155c9f73e4ca3966a6ed0cc7234651f"
-binary freebsd10-x64 "https://jxcore.s3.amazonaws.com/0307/jx_bsd1064sm.zip#c594cd516f1aa68c9649b18f436efa9f61c729fb094e3b6912b6794b6ee16965"
-binary debian-x86 "https://jxcore.s3.amazonaws.com/0307/jx_deb32sm.zip#e2974ed3e8d0daa952cb8313366c507e9de2055f8b4c2cfad4271439517f82f4"
-binary debian-x64 "https://jxcore.s3.amazonaws.com/0307/jx_deb64sm.zip#a12b13237a347aed62fef753eaed274b2a179259736f23e43ce3d89bab387504"
-binary debian-arm64 "https://jxcore.s3.amazonaws.com/0307/jx_debARMsm.zip#54d24822afafad5dff7b59a62e89a8d4a53cb4f7fa2926b4568a10766a6a764f"
-binary debian-armv7l "https://jxcore.s3.amazonaws.com/0307/jx_debARMsm.zip#54d24822afafad5dff7b59a62e89a8d4a53cb4f7fa2926b4568a10766a6a764f"
-binary debian-mips "https://jxcore.s3.amazonaws.com/0307/jx_debMIPSsm.zip#67c41abce081368b533ef7b20ae47e5a188e3ca70994f22bc01f81623710fdf2"
-binary darwin-x64 "https://jxcore.s3.amazonaws.com/0307/jx_osx64sm.zip#bdfe3d09b9ee1662bacd751b9e34241acc7dddcff732662595fe69c625e8c897"
-binary redhat-x64 "https://jxcore.s3.amazonaws.com/0307/jx_rh64sm.zip#87b62a0e648895d4b6834b3e94911f9dff86d97d7aa6fc0202fb4a6c0f109cca"
-binary suse-x64 "https://jxcore.s3.amazonaws.com/0307/jx_suse64sm.zip#b412e9cd7d5073a1abdeb57ac26870ec37650ffbad23e27a465ef566e27b53b8"
-binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0307/jx_ub32sm.zip#21926feed8baf44c00fb002829191b55399809192f72b44f9170e7830c24fba9"
-binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0307/jx_ub64sm.zip#35ff53927e40105bed20fa41fb00c0dfb99ff69430362874db36ba7f72feae9b"
-
-install_package jxcore-0.3.0.7 "https://github.com/jxcore/jxcore/archive/v0.3.0.7.tar.gz#a5d3daeb736981cafc41eee70c62994bdc9001a88a6a15771624c018c74463c3" jxcore_spidermonkey standard
+install_package jxcore-0.3.0.7 "https://github.com/jxcore/jxcore/archive/v0.3.0.7.tar.gz#b50cffee1b8b0f0965925ccf02a1540e65203eb86aff53ea45a75d2e96335ccc" jxcore_spidermonkey standard
 install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.0.7/npmjx307.tar.gz#7b99397f17f5fdb592842ccd62e25806b2a05ae9997c4508b47412f194e8ba6e" jxcore_npm

--- a/share/node-build/jxcore+sm-0.3.1.0
+++ b/share/node-build/jxcore+sm-0.3.1.0
@@ -6,18 +6,5 @@ after_install_package() {
   fix_jxcore_directory_structure
 }
 
-binary freebsd9-x64 "https://jxcore.s3.amazonaws.com/0310/jx_bsd964sm.zip#3e2f1d557e3255e506be7d87dc37f871940162e52fc6abafc5b60a3bbee79442"
-binary freebsd10-x64 "https://jxcore.s3.amazonaws.com/0310/jx_bsd1064sm.zip#c30c3d7276a83a825cf8c0ce03d5096a95c90cdc341a4d4a729493e727d4bdbd"
-binary debian-x86 "https://jxcore.s3.amazonaws.com/0310/jx_deb32sm.zip#f9307e00b6f9257f39c9f076ce504dc44f1af0556f1121b7f53280c38ff78e70"
-binary debian-x64 "https://jxcore.s3.amazonaws.com/0310/jx_deb64sm.zip#8152eeafecddbcb4450f8bca25decc0adaa8d3fa78c5dae1e5c489200b6fbe0f"
-binary debian-arm64 "https://jxcore.s3.amazonaws.com/0310/jx_debARMsm.zip#688ff7c2d99cf79738aade3cc5dac6b4b048824d0d166641799b61515f5ef892"
-binary debian-armv7l "https://jxcore.s3.amazonaws.com/0310/jx_debARMsm.zip#688ff7c2d99cf79738aade3cc5dac6b4b048824d0d166641799b61515f5ef892"
-binary debian-mips "https://jxcore.s3.amazonaws.com/0310/jx_debMIPSsm.zip#28b395906b0215fc6ea7ae212136908f136ace4476ef42c2caa8f7d6d93299d9"
-binary darwin-x64 "https://jxcore.s3.amazonaws.com/0310/jx_osx64sm.zip#a3f21624178c13050da3e7f968bc7ae7e9ca0707a9938d791c126996d6be4eb7"
-binary redhat-x64 "https://jxcore.s3.amazonaws.com/0310/jx_rh64sm.zip#c46de5284250e167b5fe1e25ab2aca05ef7311c4289d6575d62f852cb007082a"
-binary suse-x64 "https://jxcore.s3.amazonaws.com/0310/jx_suse64sm.zip#c40e1a128df001b5b5e4554d2c625214e58513768627f116d573125590be5b04"
-binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0310/jx_ub32sm.zip#ac85fe3ac35149aeb4449d6899e82a98ac5e6ebc8fc43fa6c16bdcf666979ab8"
-binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0310/jx_ub64sm.zip#e299ee14fae34f19bb8f838b188aca36266a305950625e909e615923dd15c4be"
-
-install_package jxcore-0.3.1.0 "https://github.com/jxcore/jxcore/archive/v0.3.1.0.tar.gz#cae9dac0602667b5b5dedf2ac23445e2875c2bfb91cbdfd7b370790f8a0c96df" jxcore_spidermonkey standard
+install_package jxcore-0.3.1.0 "https://github.com/jxcore/jxcore/archive/v0.3.1.0.tar.gz#c519846536aa2c038278c230cc28dee478b7f000509b0302f9bff333de3018c9" jxcore_spidermonkey standard
 install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.1.0/npmjx310.tar.gz#3c8e1b1fed9be44c4ec6fd09e6978a29c3e466f684e2812f6762c0a6d28fb85c" jxcore_npm

--- a/share/node-build/jxcore+sm-0.3.1.1
+++ b/share/node-build/jxcore+sm-0.3.1.1
@@ -6,18 +6,18 @@ after_install_package() {
   fix_jxcore_directory_structure
 }
 
-binary freebsd9-x64 "https://jxcore.s3.amazonaws.com/0311/jx_bsd964sm.zip#47afe9ddc40d477aa4a0794238923f9093d7f9b44c6e454bc847ae3c9e11982c"
-binary freebsd10-x64 "https://jxcore.s3.amazonaws.com/0311/jx_bsd1064sm.zip#d3d51bbd2678ee82468ffd6133def57ec18078cf80522e8100ca74aa78e95fb9"
-binary debian-x86 "https://jxcore.s3.amazonaws.com/0311/jx_deb32sm.zip#1063398ca43d2126d026e4682d48cf96e169596d29f7fd9c526903ecd2cc83c3"
-binary debian-x64 "https://jxcore.s3.amazonaws.com/0311/jx_deb64sm.zip#ff76c4564f11e1371e3ff4d5d495092ed01bd4ebcee0102b10ef288ab6d6ecdf"
-binary debian-arm64 "https://jxcore.s3.amazonaws.com/0311/jx_debARMsm.zip#3f0d7ab72cd93d3be2d6c8b47ba43269ddc7970ba9785f312514e0815e201565"
-binary debian-armv7l "https://jxcore.s3.amazonaws.com/0311/jx_debARMsm.zip#3f0d7ab72cd93d3be2d6c8b47ba43269ddc7970ba9785f312514e0815e201565"
-binary debian-mips "https://jxcore.s3.amazonaws.com/0311/jx_debMIPSsm.zip#cc815038ada3dbb3239fd72fb76b2de65c209a0733779126b3b90419fd80410d"
-binary darwin-x64 "https://jxcore.s3.amazonaws.com/0311/jx_osx64sm.zip#ca7e6339906fc08483673ea36fe9a49cec319894751035fec9a96b249250fca1"
-binary redhat-x64 "https://jxcore.s3.amazonaws.com/0311/jx_rh64sm.zip#a85b46ce8473160004cbe4a69176721fe626376d36049cbcd820fe7b1e8bac8e"
-binary suse-x64 "https://jxcore.s3.amazonaws.com/0311/jx_suse64sm.zip#c10c85b6eb3be9daabe1989adf8ffa2c725cdaff85d16f16bf149cdf89438bfa"
-binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0311/jx_ub32sm.zip#cd8713e85838a59f421cba51ce488d63fe4ad50046b5d595759797360526aa61"
-binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0311/jx_ub64sm.zip#9f8df5354fc3d7c7148a53bf307183e36f104eb66b0bfb46bfa7e276f2b927d0"
+binary freebsd9-x64 "https://github.com/jxcore/jxcore-release/blob/master/0311/jx_bsd964sm.zip?raw=true#47afe9ddc40d477aa4a0794238923f9093d7f9b44c6e454bc847ae3c9e11982c"
+binary freebsd10-x64 "https://github.com/jxcore/jxcore-release/blob/master/0311/jx_bsd1064sm.zip?raw=true#d3d51bbd2678ee82468ffd6133def57ec18078cf80522e8100ca74aa78e95fb9"
+binary debian-x86 "https://github.com/jxcore/jxcore-release/blob/master/0311/jx_deb32sm.zip?raw=true#1063398ca43d2126d026e4682d48cf96e169596d29f7fd9c526903ecd2cc83c3"
+binary debian-x64 "https://github.com/jxcore/jxcore-release/blob/master/0311/jx_deb64sm.zip?raw=true#ff76c4564f11e1371e3ff4d5d495092ed01bd4ebcee0102b10ef288ab6d6ecdf"
+binary debian-arm64 "https://github.com/jxcore/jxcore-release/blob/master/0311/jx_debARMsm.zip?raw=true#3f0d7ab72cd93d3be2d6c8b47ba43269ddc7970ba9785f312514e0815e201565"
+binary debian-armv7l "https://github.com/jxcore/jxcore-release/blob/master/0311/jx_debARMsm.zip?raw=true#3f0d7ab72cd93d3be2d6c8b47ba43269ddc7970ba9785f312514e0815e201565"
+binary debian-mips "https://github.com/jxcore/jxcore-release/blob/master/0311/jx_debMIPSsm.zip?raw=true#cc815038ada3dbb3239fd72fb76b2de65c209a0733779126b3b90419fd80410d"
+binary darwin-x64 "https://github.com/jxcore/jxcore-release/blob/master/0311/jx_osx64sm.zip?raw=true#ca7e6339906fc08483673ea36fe9a49cec319894751035fec9a96b249250fca1"
+binary redhat-x64 "https://github.com/jxcore/jxcore-release/blob/master/0311/jx_rh64sm.zip?raw=true#a85b46ce8473160004cbe4a69176721fe626376d36049cbcd820fe7b1e8bac8e"
+binary suse-x64 "https://github.com/jxcore/jxcore-release/blob/master/0311/jx_suse64sm.zip?raw=true#c10c85b6eb3be9daabe1989adf8ffa2c725cdaff85d16f16bf149cdf89438bfa"
+binary ubuntu-x86 "https://github.com/jxcore/jxcore-release/blob/master/0311/jx_ub32sm.zip?raw=true#cd8713e85838a59f421cba51ce488d63fe4ad50046b5d595759797360526aa61"
+binary ubuntu-x64 "https://github.com/jxcore/jxcore-release/blob/master/0311/jx_ub64sm.zip?raw=true#9f8df5354fc3d7c7148a53bf307183e36f104eb66b0bfb46bfa7e276f2b927d0"
 
-install_package jxcore-0.3.1.1 "https://github.com/jxcore/jxcore/archive/v0.3.1.1.tar.gz#a1a44e0a06158245320a2aca20a7381469a453f3c5e2bc1ce36fdb470801c1f5" jxcore_spidermonkey standard
+install_package jxcore-0.3.1.1 "https://github.com/jxcore/jxcore/archive/v0.3.1.1.tar.gz#a29e139f10d85f3cb145e113182f8d8b00a381ebe70cde087e55f89afe47999b" jxcore_spidermonkey standard
 install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.1.1/npmjx311.tar.gz#b0a696e01db4af87c2b6978453a01e4294951dd915d4770b559cab918a20c127" jxcore_npm

--- a/share/node-build/jxcore+sm-dev
+++ b/share/node-build/jxcore+sm-dev
@@ -7,4 +7,4 @@ after_install_package() {
 }
 
 install_git jxcore-dev "https://github.com/jxcore/jxcore.git" "master" jxcore_spidermonkey standard
-install_package npm "https://s3.amazonaws.com/nodejx/npmjx310.tar.gz#3c8e1b1fed9be44c4ec6fd09e6978a29c3e466f684e2812f6762c0a6d28fb85c" jxcore_npm
+install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.1.1/npmjx311.tar.gz#b0a696e01db4af87c2b6978453a01e4294951dd915d4770b559cab918a20c127" jxcore_npm

--- a/share/node-build/jxcore+v8-0.3.0.0
+++ b/share/node-build/jxcore+v8-0.3.0.0
@@ -6,16 +6,5 @@ after_install_package() {
   fix_jxcore_directory_structure
 }
 
-binary debian-x86 "https://jxcore.s3.amazonaws.com/0300/jx_deb32v8.zip#e81b11821b27ba7231f52eafb8757a8f906d614bffec8896b192cf27381fb285"
-binary debian-x64 "https://jxcore.s3.amazonaws.com/0300/jx_deb64v8.zip#b5bbbe05bc8106ecbf26c9e699e5b8b5d300b54fcb861be4b28af7729423bec7"
-binary debian-arm64 "https://jxcore.s3.amazonaws.com/0300/jx_debARMv8.zip#8b77932ee38fbc6954543ef81d2e959d0e03bf64b9e8b92daa8350faa776067e"
-binary debian-armv7l "https://jxcore.s3.amazonaws.com/0300/jx_debARMv8.zip#8b77932ee38fbc6954543ef81d2e959d0e03bf64b9e8b92daa8350faa776067e"
-binary debian-mips "https://jxcore.s3.amazonaws.com/0300/jx_debMIPSv8.zip#f8fc94df341601f8e02f13a8a06bfc322c1fe11fa02e79a13d735d805ec39a18"
-binary darwin-x64 "https://jxcore.s3.amazonaws.com/0300/jx_osx64v8.zip#ab9f44ad9dae9742a74fbdbba7140af8cb9b4159f579881c2f37eeb7039f0323"
-binary redhat-x64 "https://jxcore.s3.amazonaws.com/0300/jx_rh64v8.zip#66b2a58a4ca1cf3ec0b1161e64df430899ecc7dcfb7ebd4430ae741df1959b58"
-binary suse-x64 "https://jxcore.s3.amazonaws.com/0300/jx_suse64v8.zip#ce7a7ca9db3b51500fdfa6b940e575f8d93f41f43774679c23c6436c922a6e9c"
-binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0300/jx_ub32v8.zip#d54228a58ae658fb50e866c4236801faf1f13a26b429a8a4de9ec7c325948024"
-binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0300/jx_ub64v8.zip#02ddb8b7fd41714927ef292c1362ca36d14afa9f04d2cc79d31e1925fc2ad6c2"
-
-install_package jxcore-0.3.0.0 "https://github.com/jxcore/jxcore/archive/v0.3.0.tar.gz#1e76648ecd012a2370354369f6161666763b4bc028544e9dc0cb27c035a90f24"
+install_package jxcore-0.3.0.0 "https://github.com/jxcore/jxcore/archive/v0.3.0.tar.gz#e25371772860439ee12824cc8760ccf5f6747586bc4c6bc0ef9081eb32842e1c"
 install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.0/npmjx300.tar.gz#cfb8b86a39b790cabb236aa5c8bde99e4c743579c2d0118468b3e86ed9ec6298" jxcore_npm

--- a/share/node-build/jxcore+v8-0.3.0.1
+++ b/share/node-build/jxcore+v8-0.3.0.1
@@ -6,18 +6,5 @@ after_install_package() {
   fix_jxcore_directory_structure
 }
 
-binary freebsd9-x64 "https://jxcore.s3.amazonaws.com/0301/jx_bsd964v8.zip#94b6f671251047aef3ee0c3b3336ff75a34d749ad6b955887c3fde17fb2055d4"
-binary freebsd10-x64 "https://jxcore.s3.amazonaws.com/0301/jx_bsd1064v8.zip#fa2438a4ee7f3203cd770b6d3c9063ff5efa88180e6a1f35f99b5429eabfe168"
-binary debian-x86 "https://jxcore.s3.amazonaws.com/0301/jx_deb32v8.zip#803038a89e4f2f5fb75bc07f692c04c85b78dae13d4ac728519efc7a56073eca"
-binary debian-x64 "https://jxcore.s3.amazonaws.com/0301/jx_deb64v8.zip#44488230dc60c5e5061e59bef909da014cae28de89c21f513ec80e865e02b93f"
-binary debian-arm64 "https://jxcore.s3.amazonaws.com/0301/jx_debARMv8.zip#0e78ed3c95fa8cf000a51b5ea7236a4caa604e2535ce9da5cdb54ce008b8e5db"
-binary debian-armv7l "https://jxcore.s3.amazonaws.com/0301/jx_debARMv8.zip#0e78ed3c95fa8cf000a51b5ea7236a4caa604e2535ce9da5cdb54ce008b8e5db"
-binary debian-mips "https://jxcore.s3.amazonaws.com/0301/jx_debMIPSv8.zip#d0c3afb457f782b00024ffd0b1c7f366cfca007e7135428e06400ec4aa19886b"
-binary darwin-x64 "https://jxcore.s3.amazonaws.com/0301/jx_osx64v8.zip#cc2389007ffebeb91b49312989423280296fdced43493e0e6339bd2f8fa4ae13"
-binary redhat-x64 "https://jxcore.s3.amazonaws.com/0301/jx_rh64v8.zip#04d641d7de863d3c072aba3f82eaa4e11a492f0b21467cb8dd940e029a095500"
-binary suse-x64 "https://jxcore.s3.amazonaws.com/0301/jx_suse64v8.zip#b454a40bb330bd0abb2a4b2465440d9de9d84127d8a8e3c763106b31f868e29d"
-binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0301/jx_ub32v8.zip#59bc363ab28d044a098ef42927582f87b3a9c8cad894bed0d73caae3a7539dbd"
-binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0301/jx_ub64v8.zip#36ac32276d9fdfee9778718cbb0571ec4bc61680e91c5042a6cd8870d0308a9b"
-
-install_package jxcore-0.3.0.1 "https://github.com/jxcore/jxcore/archive/v0.3.0.1.tar.gz#fd25b575b4dd42be87f9681dbcf9812836bc6389f6d90073913092085e902a44"
+install_package jxcore-0.3.0.1 "https://github.com/jxcore/jxcore/archive/v0.3.0.1.tar.gz#39fd70b28e85be85d621e3f770d3a0be8aa56efec6b4bac206dfc4472ce55b55"
 install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.0.1/npmjx300.tar.gz#cfb8b86a39b790cabb236aa5c8bde99e4c743579c2d0118468b3e86ed9ec6298" jxcore_npm

--- a/share/node-build/jxcore+v8-0.3.0.2
+++ b/share/node-build/jxcore+v8-0.3.0.2
@@ -6,18 +6,5 @@ after_install_package() {
   fix_jxcore_directory_structure
 }
 
-binary freebsd9-x64 "https://jxcore.s3.amazonaws.com/0302/jx_bsd964v8.zip#5af84d13312c9438c1ad5d532655276c74ebf0afb72a0e5abcac03aca8d5722d"
-binary freebsd10-x64 "https://jxcore.s3.amazonaws.com/0302/jx_bsd1064v8.zip#194accf65cead5c854b04ce9cdd3f630eeec2b12ebec8d1ebaa1222eed3c8d72"
-binary debian-x86 "https://jxcore.s3.amazonaws.com/0302/jx_deb32v8.zip#835ec646221cba4f9cc6d330f89b30829431549a6aa3f38bcba4cb16e380eeb4"
-binary debian-x64 "https://jxcore.s3.amazonaws.com/0302/jx_deb64v8.zip#7d32b62687e179538dd307728d4dfea616cf0a80559c68d9c0d5707a27e1ee05"
-binary debian-arm64 "https://jxcore.s3.amazonaws.com/0302/jx_debARMv8.zip#f4a9306d06d424be7bfce7e0ddfc84138969e04bc9886d060930e79a6ae5a867"
-binary debian-armv7l "https://jxcore.s3.amazonaws.com/0302/jx_debARMv8.zip#f4a9306d06d424be7bfce7e0ddfc84138969e04bc9886d060930e79a6ae5a867"
-binary debian-mips "https://jxcore.s3.amazonaws.com/0302/jx_debMIPSv8.zip#f4fde5e59f201eb74dff13dd5175a39353996163f05f9cd186ca65bdb2ae04cd"
-binary darwin-x64 "https://jxcore.s3.amazonaws.com/0302/jx_osx64v8.zip#9d8c3e6db5c9dd3759b4fad6fb8fb95fb64a1f4f53ddd460b30cbafa9c433db8"
-binary redhat-x64 "https://jxcore.s3.amazonaws.com/0302/jx_rh64v8.zip#5e13095cf6b52b699b055a7696ba1ccfed83aa1255b962d98afe0b0ccd18a8ee"
-binary suse-x64 "https://jxcore.s3.amazonaws.com/0302/jx_suse64v8.zip#12098decaf41c25f40d42309b8e453b6c790ae6960ef9f25acafeea4063d9ecb"
-binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0302/jx_ub32v8.zip#f680e0d7f3310acbfc25929f115b24bee77e7eee3276bb0d5e3dcdce2108d0e0"
-binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0302/jx_ub64v8.zip#c87fb4a92ae193009e646d851c89178291374a0e41f83a75bdb4ed48e129474f"
-
-install_package jxcore-0.3.0.2 "https://github.com/jxcore/jxcore/archive/v0.3.0.2.tar.gz#79baa480676ef44a93d2cf6081b4d001ecf09cb746b73143cf264e8ba8601b96"
+install_package jxcore-0.3.0.2 "https://github.com/jxcore/jxcore/archive/v0.3.0.2.tar.gz#84341e930fb160432553c7a35227d47c147403eaec5253d3ebf65f9410b01e35"
 install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.0.2/npmjx300.tar.gz#cfb8b86a39b790cabb236aa5c8bde99e4c743579c2d0118468b3e86ed9ec6298" jxcore_npm

--- a/share/node-build/jxcore+v8-0.3.0.3
+++ b/share/node-build/jxcore+v8-0.3.0.3
@@ -6,18 +6,5 @@ after_install_package() {
   fix_jxcore_directory_structure
 }
 
-binary freebsd9-x64 "https://jxcore.s3.amazonaws.com/0303/jx_bsd964v8.zip#f249c3e111954578ec9f901ecbd21971e023aae3634848c17a571de50f61c17b"
-binary freebsd10-x64 "https://jxcore.s3.amazonaws.com/0303/jx_bsd1064v8.zip#90af42fc8dde2cd786c5f6b45ff64af7450e3f636d1462cd749b53a4cc60ab7d"
-binary debian-x86 "https://jxcore.s3.amazonaws.com/0303/jx_deb32v8.zip#6b7b96d6d20d0ffcb892a19c4a3ec7eaa4d6c012a68a805f2748e8bd02300934"
-binary debian-x64 "https://jxcore.s3.amazonaws.com/0303/jx_deb64v8.zip#9750ddaf7b9e6af0b53497ae536d6878fdc1b3310d2a383a2dbfd474b5878366"
-binary debian-arm64 "https://jxcore.s3.amazonaws.com/0303/jx_debARMv8.zip#9afb531c6fabc45fe8f152bc2b284914d3cc511e7c345aea943fe91aa52ff38d"
-binary debian-armv7l "https://jxcore.s3.amazonaws.com/0303/jx_debARMv8.zip#9afb531c6fabc45fe8f152bc2b284914d3cc511e7c345aea943fe91aa52ff38d"
-binary debian-mips "https://jxcore.s3.amazonaws.com/0303/jx_debMIPSv8.zip#9a5686cf1834bae32be843e4801b81bfe7ec4a13f7b021c8f2d1bc1846eeba91"
-binary darwin-x64 "https://jxcore.s3.amazonaws.com/0303/jx_osx64v8.zip#122ffe5086e72e2adf447b6c9852c2ead54a430dcf75603edf079f5b4b974faf"
-binary redhat-x64 "https://jxcore.s3.amazonaws.com/0303/jx_rh64v8.zip#2b6fea23159be6dec039f9acc4672041b02333245d7944b74325ca36530d187b"
-binary suse-x64 "https://jxcore.s3.amazonaws.com/0303/jx_suse64v8.zip#80f3ab32b63ff4c6b6a8f86eed11865bf8414bbd6e0ab94ca8679aa16db38b16"
-binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0303/jx_ub32v8.zip#d5f481f10aad3802ce8368b6a5a381a5557839e19da6d541d17898dcb2fd7099"
-binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0303/jx_ub64v8.zip#257d484f2e563984b6104a3fdb4cf99e7b01bb77a289a0ade045f1e998ec584c"
-
-install_package jxcore-0.3.0.3 "https://github.com/jxcore/jxcore/archive/v0.3.0.3.tar.gz#b8e4f5c791f130fb0dd51fc0489bdadf5b4dfd2ed56e050943d3269631e1ccdc"
+install_package jxcore-0.3.0.3 "https://github.com/jxcore/jxcore/archive/v0.3.0.3.tar.gz#74be5759ff5264746a0072642720384cace3b888997dacad867424386abdcf8e"
 install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.0.3/npmjx303.tar.gz#f3479e698f7d9288256b944cfb14842349364575a2819bd4d635ec79924c6368" jxcore_npm

--- a/share/node-build/jxcore+v8-0.3.0.4
+++ b/share/node-build/jxcore+v8-0.3.0.4
@@ -6,18 +6,5 @@ after_install_package() {
   fix_jxcore_directory_structure
 }
 
-binary freebsd9-x64 "https://jxcore.s3.amazonaws.com/0304/jx_bsd964v8.zip#4b81a1252a0ef65ee4108543687f2ea5b591d6dfa901cdc91363ace63551c3c0"
-binary freebsd10-x64 "https://jxcore.s3.amazonaws.com/0304/jx_bsd1064v8.zip#68ca3b43c7e755ec319320b93792fe527097f69f11de1d4966af83d0110e0b96"
-binary debian-x86 "https://jxcore.s3.amazonaws.com/0304/jx_deb32v8.zip#67ef10b777c795c3b84927c61075c095911724f261d5e1b3a2bcd49a5122fc24"
-binary debian-x64 "https://jxcore.s3.amazonaws.com/0304/jx_deb64v8.zip#84455fe7586ba7a2c13be9664b8585372c2da5bf61789851ee5a58756f4aff76"
-binary debian-arm64 "https://jxcore.s3.amazonaws.com/0304/jx_debARMv8.zip#a354f8f91e04ebe4123836dc805af43cf92f533fc30838d27473f5d218cd728d"
-binary debian-armv7l "https://jxcore.s3.amazonaws.com/0304/jx_debARMv8.zip#a354f8f91e04ebe4123836dc805af43cf92f533fc30838d27473f5d218cd728d"
-binary debian-mips "https://jxcore.s3.amazonaws.com/0304/jx_debMIPSv8.zip#0a1239b34a68fb6e125959a0934b3cfc4104014c871f2bbba53acdac37d03964"
-binary darwin-x64 "https://jxcore.s3.amazonaws.com/0304/jx_osx64v8.zip#b94c8577f1c3916a17644f5380237c04bf13a926977ebd2afe65f144295261e5"
-binary redhat-x64 "https://jxcore.s3.amazonaws.com/0304/jx_rh64v8.zip#2657b161e02e7e993d91c26b2f389adf886801293b9f478033d6d0ba05e5896d"
-binary suse-x64 "https://jxcore.s3.amazonaws.com/0304/jx_suse64v8.zip#0f368cb1ee679482fd333d6f7b41faa7b6995c2c8bf4766ae0c9c52d010b63c1"
-binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0304/jx_ub32v8.zip#d8f33ca1544ff89213d65d733511cec6a41e9f384352a4b5310babd0b22baac4"
-binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0304/jx_ub64v8.zip#8a268aa4a6128d214abdfec88c5a636c8ccdffa90f42a038dfb75f87493bb81e"
-
-install_package jxcore-0.3.0.4 "https://github.com/jxcore/jxcore/archive/v0.3.0.4.tar.gz#84e67ee008abb6794940806ab2992536144d9e831643181ea0230f4e8f1aade7"
+install_package jxcore-0.3.0.4 "https://github.com/jxcore/jxcore/archive/v0.3.0.4.tar.gz#44331fe17190f7035d74ef91e5b15c8e888c5ddb8005bfbb1f1ef1a5de6fd2a8"
 install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.0.4/npmjx304.tar.gz#e12617fe36c58c59ee5d06e99f421f21b8a3215d5d780597e5218e2c6b63f17a" jxcore_npm

--- a/share/node-build/jxcore+v8-0.3.0.5
+++ b/share/node-build/jxcore+v8-0.3.0.5
@@ -6,18 +6,5 @@ after_install_package() {
   fix_jxcore_directory_structure
 }
 
-binary freebsd9-x64 "https://jxcore.s3.amazonaws.com/0305/jx_bsd964v8.zip#b58c568b701f88dfd4e03b9cd2a1d30bdc31078aacdb5640bd9d0c26b75f6216"
-binary freebsd10-x64 "https://jxcore.s3.amazonaws.com/0305/jx_bsd1064v8.zip#b6acd152291a7c95e8603bf795181d8978b638eee279e09296f6a5b8ce6386dd"
-binary debian-x86 "https://jxcore.s3.amazonaws.com/0305/jx_deb32v8.zip#f665495b9f49ecd8e0712eea4fc725c68c1101566e9e7fcb92ec1c98df47f4e7"
-binary debian-x64 "https://jxcore.s3.amazonaws.com/0305/jx_deb64v8.zip#e52a9ffc9dbd681ef934ac9217185856ec8c574a1a57dfb38a03652a4719ff09"
-binary debian-arm64 "https://jxcore.s3.amazonaws.com/0305/jx_debARMv8.zip#f68cc7c7018ccb844563dcf73679fe252f7e7bdc093c8be931536a721a1e3d0e"
-binary debian-armv7l "https://jxcore.s3.amazonaws.com/0305/jx_debARMv8.zip#f68cc7c7018ccb844563dcf73679fe252f7e7bdc093c8be931536a721a1e3d0e"
-binary debian-mips "https://jxcore.s3.amazonaws.com/0305/jx_debMIPSv8.zip#22b93299635e43143a1d39f75ed8d5af9292ab52040da964d5ff9e465c67146f"
-binary darwin-x64 "https://jxcore.s3.amazonaws.com/0305/jx_osx64v8.zip#83094ec594cdaae1e94f4dcd5d81018c056902ae2134cd727e7b448899b9ae92"
-binary redhat-x64 "https://jxcore.s3.amazonaws.com/0305/jx_rh64v8.zip#fb3d04e5e283f299acce328d498c19e90647228dc57b576262615846c59652fd"
-binary suse-x64 "https://jxcore.s3.amazonaws.com/0305/jx_suse64v8.zip#4afad1d2c114a43da9cd2b0a6331d6f9fa29070ed2c1c6665ab5e52af52ce97f"
-binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0305/jx_ub32v8.zip#fc893263bf8252bef52e8ba4ebab1c195fb18437db941c20168755e5e3a02685"
-binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0305/jx_ub64v8.zip#44ffa659f01c3ea4d886a4a4bab17afaff87c5f6f447fe1ebedaa63ec4fd4990"
-
-install_package jxcore-0.3.0.5 "https://github.com/jxcore/jxcore/archive/v0.3.0.5.tar.gz#a7c7759f66609f32bc2aed5f3674e251d66710bb742417faf5c0059319cc00b5"
+install_package jxcore-0.3.0.5 "https://github.com/jxcore/jxcore/archive/v0.3.0.5.tar.gz#818572e99c6b047a1bbd72889308c2e3636329f92e3107cfa7ae5499ec66e398"
 install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.0.5/npmjx305.tar.gz#fdefdb122e6ca0ea23a11730c7e032742a86b2c7e9e46421304bc6b7ce99a7fa" jxcore_npm

--- a/share/node-build/jxcore+v8-0.3.0.6
+++ b/share/node-build/jxcore+v8-0.3.0.6
@@ -6,18 +6,5 @@ after_install_package() {
   fix_jxcore_directory_structure
 }
 
-binary freebsd9-x64 "https://jxcore.s3.amazonaws.com/0306/jx_bsd964v8.zip#ade16ec944e9d2ebead2ec1c9719a4220834a1b2f0c59053d1061356c05d60cb"
-binary freebsd10-x64 "https://jxcore.s3.amazonaws.com/0306/jx_bsd1064v8.zip#aaba8e2841f8a0057671b2690d2d839bb7dd974aa49b16641a2d6875692372ae"
-binary debian-x86 "https://jxcore.s3.amazonaws.com/0306/jx_deb32v8.zip#d5c2c4ad031308e7129df64de97fa7fb61d89be92f27504f258ab7e7b34da134"
-binary debian-x64 "https://jxcore.s3.amazonaws.com/0306/jx_deb64v8.zip#6e9f76406bcc9682bcc7cae2deba0e2b8f7bbcc0940630d90d2e3c54d420ea1a"
-binary debian-arm64 "https://jxcore.s3.amazonaws.com/0306/jx_debARMv8.zip#71b911870dcac7a9bd1ca8331a31d4ff1200d0c3cf841061f85bec67acf3baca"
-binary debian-armv7l "https://jxcore.s3.amazonaws.com/0306/jx_debARMv8.zip#71b911870dcac7a9bd1ca8331a31d4ff1200d0c3cf841061f85bec67acf3baca"
-binary debian-mips "https://jxcore.s3.amazonaws.com/0306/jx_debMIPSv8.zip#400c5344b18d65204e29dfcfd0b5bf71db091056e11b530230663b1f2d666e7f"
-binary darwin-x64 "https://jxcore.s3.amazonaws.com/0306/jx_osx64v8.zip#be1decabfa4334327e2c559004e562dc51c310448231402d8c88fb27efa24576"
-binary redhat-x64 "https://jxcore.s3.amazonaws.com/0306/jx_rh64v8.zip#d4b3ead759b61919a90d22d13c57f20160720788d000ad995f09a6efa4609c18"
-binary suse-x64 "https://jxcore.s3.amazonaws.com/0306/jx_suse64v8.zip#a3c1fffb47bb74f0bb14221e7e391365721deb53f85d0102d745416fea650b69"
-binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0306/jx_ub32v8.zip#fcdeaf029f293437ed3e2811006cb96f27ce52178abe4004a0fe48d42be71a57"
-binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0306/jx_ub64v8.zip#675766946cc2baf8727f96cbd57223ce0f6add0fb9342445bd6a8ebcf25a3112"
-
-install_package jxcore-0.3.0.6 "https://github.com/jxcore/jxcore/archive/v0.3.0.6.tar.gz#8e978743f126c27ba6478873013d71575af23082c1804f3cbaa911d720ef0f19"
+install_package jxcore-0.3.0.6 "https://github.com/jxcore/jxcore/archive/v0.3.0.6.tar.gz#ba77e9583b6c305c20a03a3d5443a01d96b99785fbaa17b8569cf68b5be8903d"
 install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.0.6/npmjx305.tar.gz#fdefdb122e6ca0ea23a11730c7e032742a86b2c7e9e46421304bc6b7ce99a7fa" jxcore_npm

--- a/share/node-build/jxcore+v8-0.3.0.7
+++ b/share/node-build/jxcore+v8-0.3.0.7
@@ -6,18 +6,5 @@ after_install_package() {
   fix_jxcore_directory_structure
 }
 
-binary freebsd9-x64 "https://jxcore.s3.amazonaws.com/0307/jx_bsd964v8.zip#d3ef3e7f6a31e7e37e5bb9a953c05741e434b92d6cdc4bcaf8cc55058fe33c6c"
-binary freebsd10-x64 "https://jxcore.s3.amazonaws.com/0307/jx_bsd1064v8.zip#68b2a3ba84ae5c11cecb5516105a45e9e6dba97e8b9330216e3f450377280422"
-binary debian-x86 "https://jxcore.s3.amazonaws.com/0307/jx_deb32v8.zip#8ee27b604596ccc2229501864055d213f4045582ca993fa66ba16b4b60cc8f94"
-binary debian-x64 "https://jxcore.s3.amazonaws.com/0307/jx_deb64v8.zip#68e1ef5b5adada431d12bdb45caf66bd3c2ceb0469fd4f6e2966ed282bd41052"
-binary debian-arm64 "https://jxcore.s3.amazonaws.com/0307/jx_debARMv8.zip#387b37b65c6edcc33a082c6a05857df32c94439183439c537b09f17cf52be168"
-binary debian-armv7l "https://jxcore.s3.amazonaws.com/0307/jx_debARMv8.zip#387b37b65c6edcc33a082c6a05857df32c94439183439c537b09f17cf52be168"
-binary debian-mips "https://jxcore.s3.amazonaws.com/0307/jx_debMIPSv8.zip#a60bebda247c784b3d3558862cf0f9c1de13291ea536f5e1f5a12d30304901ef"
-binary darwin-x64 "https://jxcore.s3.amazonaws.com/0307/jx_osx64v8.zip#e1429ac931225c1efa7a5f3b184b0b7a8d28871a64248beb0d9b9de688d23e24"
-binary redhat-x64 "https://jxcore.s3.amazonaws.com/0307/jx_rh64v8.zip#929d1266a5979f30eff590c276f0e18cefbd0771f4dd47eaa7294ebee5b0335c"
-binary suse-x64 "https://jxcore.s3.amazonaws.com/0307/jx_suse64v8.zip#139eab46f51910392519576b06c9a51aeba7cf4a74547e79b857c979bfce9394"
-binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0307/jx_ub32v8.zip#3b33c65c7196c1621612cb4f047abf26f81184eb172550363146a3c7e7724d37"
-binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0307/jx_ub64v8.zip#60368d54f71d6a66bbeebabb8cabcdd81c20bf1a6daa7bdca0d98062e1087330"
-
-install_package jxcore-0.3.0.7 "https://github.com/jxcore/jxcore/archive/v0.3.0.7.tar.gz#a5d3daeb736981cafc41eee70c62994bdc9001a88a6a15771624c018c74463c3"
+install_package jxcore-0.3.0.7 "https://github.com/jxcore/jxcore/archive/v0.3.0.7.tar.gz#b50cffee1b8b0f0965925ccf02a1540e65203eb86aff53ea45a75d2e96335ccc"
 install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.0.7/npmjx307.tar.gz#7b99397f17f5fdb592842ccd62e25806b2a05ae9997c4508b47412f194e8ba6e" jxcore_npm

--- a/share/node-build/jxcore+v8-0.3.1.0
+++ b/share/node-build/jxcore+v8-0.3.1.0
@@ -6,18 +6,5 @@ after_install_package() {
   fix_jxcore_directory_structure
 }
 
-binary freebsd9-x64 "https://jxcore.s3.amazonaws.com/0310/jx_bsd964v8.zip#f6535c54fe8b36580782114300420453fbf36b75101c2976643e85beec035d8c"
-binary freebsd10-x64 "https://jxcore.s3.amazonaws.com/0310/jx_bsd1064v8.zip#124038dc5e66cac1ff5e7ff98e81da4843de0e1bc1e8a1824f1bbcd5145937d3"
-binary debian-x86 "https://jxcore.s3.amazonaws.com/0310/jx_deb32v8.zip#4cc13f61219454722ea15982a8b16da4f6fdb21dfc444da6fc96f1eb63a54bf5"
-binary debian-x64 "https://jxcore.s3.amazonaws.com/0310/jx_deb64v8.zip#d7bb5b83662bfcf3149c897ce4b2613711f21a87e5e6dae0e23d36082c804de5"
-binary debian-arm64 "https://jxcore.s3.amazonaws.com/0310/jx_debARMv8.zip#8fdaa694a1ba9de6b4d15235fcebb03dcbb984b05610dac1c06b863323109a33"
-binary debian-armv7l "https://jxcore.s3.amazonaws.com/0310/jx_debARMv8.zip#8fdaa694a1ba9de6b4d15235fcebb03dcbb984b05610dac1c06b863323109a33"
-binary debian-mips "https://jxcore.s3.amazonaws.com/0310/jx_debMIPSv8.zip#14094559e1a73e2e97eaa99cdd7cd42cd6da25f33b987ab0317b686e836c4be0"
-binary darwin-x64 "https://jxcore.s3.amazonaws.com/0310/jx_osx64v8.zip#4961cc3d890b331e3b780e85ba6b60188b975ab4d5bbce64f7d9008b0c8d8b4b"
-binary redhat-x64 "https://jxcore.s3.amazonaws.com/0310/jx_rh64v8.zip#bc3000c7f095429fd3f13a45e8cd1f5acadd2872e17b53f77bf77b4eb0f70af5"
-binary suse-x64 "https://jxcore.s3.amazonaws.com/0310/jx_suse64v8.zip#a9f1303861ddf3ae7d2eaf4d65606ed5585e6166de65341cb4ca6c0bbe877bfd"
-binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0310/jx_ub32v8.zip#d533f8fe93000b3ef595cded488ae52b7817fb6cf3860d1d28e7067694ec5e85"
-binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0310/jx_ub64v8.zip#e21abde7d6c5f7d8366c530e09de66a8fec617710988ae24b301a2dd4ea9dbcb"
-
-install_package jxcore-0.3.1.0 "https://github.com/jxcore/jxcore/archive/v0.3.1.0.tar.gz#cae9dac0602667b5b5dedf2ac23445e2875c2bfb91cbdfd7b370790f8a0c96df"
+install_package jxcore-0.3.1.0 "https://github.com/jxcore/jxcore/archive/v0.3.1.0.tar.gz#c519846536aa2c038278c230cc28dee478b7f000509b0302f9bff333de3018c9"
 install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.1.0/npmjx310.tar.gz#3c8e1b1fed9be44c4ec6fd09e6978a29c3e466f684e2812f6762c0a6d28fb85c" jxcore_npm

--- a/share/node-build/jxcore+v8-0.3.1.1
+++ b/share/node-build/jxcore+v8-0.3.1.1
@@ -6,18 +6,18 @@ after_install_package() {
   fix_jxcore_directory_structure
 }
 
-binary freebsd9-x64 "https://jxcore.s3.amazonaws.com/0311/jx_bsd964v8.zip#c744b793dc644ceb98d54deffab73d1578bc8e3b5b569b3b45e8febf6d5d07f1"
-binary freebsd10-x64 "https://jxcore.s3.amazonaws.com/0311/jx_bsd1064v8.zip#01798a20c82b6958f7a3b1ee4d2d52392ffeac5bd30d95eacd4c65647a1d615b"
-binary debian-x86 "https://jxcore.s3.amazonaws.com/0311/jx_deb32v8.zip#94a093b447ee2632baf12e69f765ebe341a9a53a3c02f655bc1b342a398e633f"
-binary debian-x64 "https://jxcore.s3.amazonaws.com/0311/jx_deb64v8.zip#9e76cee00aeccd345f2c104edca2d0f159015d8b8989bb18c91470f22b38dda8"
-binary debian-arm64 "https://jxcore.s3.amazonaws.com/0311/jx_debARMv8.zip#37795fc8256a317e099da43269627cce9abf86704e463027eb809b4cd34a48f9"
-binary debian-armv7l "https://jxcore.s3.amazonaws.com/0311/jx_debARMv8.zip#37795fc8256a317e099da43269627cce9abf86704e463027eb809b4cd34a48f9"
-binary debian-mips "https://jxcore.s3.amazonaws.com/0311/jx_debMIPSv8.zip#1f0a5d0a7a2a5fab5a8da346d9ba4fa9e54edca1ba3faed6677d8ab6a5a140e4"
-binary darwin-x64 "https://jxcore.s3.amazonaws.com/0311/jx_osx64v8.zip#6b6b380a023740503fb1231cb105d3115306fbecf7debeff3a7610458ad494e3"
-binary redhat-x64 "https://jxcore.s3.amazonaws.com/0311/jx_rh64v8.zip#59e177e7154e311cfec0c2c4580a48bf217a2befbfce8882839de6ae55a1cb59"
-binary suse-x64 "https://jxcore.s3.amazonaws.com/0311/jx_suse64v8.zip#1797be220b31756240fcf5c3ae207ee4f821c679c70c540618c532460536f1fa"
-binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0311/jx_ub32v8.zip#392bfa35add03ede1b6d18c596d586e0551141ea88d60094241e05ab9b660db1"
-binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0311/jx_ub64v8.zip#f3bd4d58f8af6e03ad1a48c95727ed1c050c2d24f12c7974797ce7d63b3dd8f0"
+binary freebsd9-x64 "https://github.com/jxcore/jxcore-release/blob/master/0311/jx_bsd964v8.zip?raw=true#c744b793dc644ceb98d54deffab73d1578bc8e3b5b569b3b45e8febf6d5d07f1"
+binary freebsd10-x64 "https://github.com/jxcore/jxcore-release/blob/master/0311/jx_bsd1064v8.zip?raw=true#01798a20c82b6958f7a3b1ee4d2d52392ffeac5bd30d95eacd4c65647a1d615b"
+binary debian-x86 "https://github.com/jxcore/jxcore-release/blob/master/0311/jx_deb32v8.zip?raw=true#94a093b447ee2632baf12e69f765ebe341a9a53a3c02f655bc1b342a398e633f"
+binary debian-x64 "https://github.com/jxcore/jxcore-release/blob/master/0311/jx_deb64v8.zip?raw=true#9e76cee00aeccd345f2c104edca2d0f159015d8b8989bb18c91470f22b38dda8"
+binary debian-arm64 "https://github.com/jxcore/jxcore-release/blob/master/0311/jx_debARMv8.zip?raw=true#37795fc8256a317e099da43269627cce9abf86704e463027eb809b4cd34a48f9"
+binary debian-armv7l "https://github.com/jxcore/jxcore-release/blob/master/0311/jx_debARMv8.zip?raw=true#37795fc8256a317e099da43269627cce9abf86704e463027eb809b4cd34a48f9"
+binary debian-mips "https://github.com/jxcore/jxcore-release/blob/master/0311/jx_debMIPSv8.zip?raw=true#1f0a5d0a7a2a5fab5a8da346d9ba4fa9e54edca1ba3faed6677d8ab6a5a140e4"
+binary darwin-x64 "https://github.com/jxcore/jxcore-release/blob/master/0311/jx_osx64v8.zip?raw=true#6b6b380a023740503fb1231cb105d3115306fbecf7debeff3a7610458ad494e3"
+binary redhat-x64 "https://github.com/jxcore/jxcore-release/blob/master/0311/jx_rh64v8.zip?raw=true#59e177e7154e311cfec0c2c4580a48bf217a2befbfce8882839de6ae55a1cb59"
+binary suse-x64 "https://github.com/jxcore/jxcore-release/blob/master/0311/jx_suse64v8.zip?raw=true#1797be220b31756240fcf5c3ae207ee4f821c679c70c540618c532460536f1fa"
+binary ubuntu-x86 "https://github.com/jxcore/jxcore-release/blob/master/0311/jx_ub32v8.zip?raw=true#392bfa35add03ede1b6d18c596d586e0551141ea88d60094241e05ab9b660db1"
+binary ubuntu-x64 "https://github.com/jxcore/jxcore-release/blob/master/0311/jx_ub64v8.zip?raw=true#f3bd4d58f8af6e03ad1a48c95727ed1c050c2d24f12c7974797ce7d63b3dd8f0"
 
-install_package jxcore-0.3.1.1 "https://github.com/jxcore/jxcore/archive/v0.3.1.1.tar.gz#a1a44e0a06158245320a2aca20a7381469a453f3c5e2bc1ce36fdb470801c1f5"
+install_package jxcore-0.3.1.1 "https://github.com/jxcore/jxcore/archive/v0.3.1.1.tar.gz#a29e139f10d85f3cb145e113182f8d8b00a381ebe70cde087e55f89afe47999b"
 install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.1.1/npmjx311.tar.gz#b0a696e01db4af87c2b6978453a01e4294951dd915d4770b559cab918a20c127" jxcore_npm

--- a/share/node-build/jxcore+v8-dev
+++ b/share/node-build/jxcore+v8-dev
@@ -7,4 +7,4 @@ after_install_package() {
 }
 
 install_git jxcore-dev "https://github.com/jxcore/jxcore.git" "master"
-install_package npm "https://s3.amazonaws.com/nodejx/npmjx310.tar.gz#3c8e1b1fed9be44c4ec6fd09e6978a29c3e466f684e2812f6762c0a6d28fb85c" jxcore_npm
+install_package npm "https://github.com/jxcore/jxcore/releases/download/v0.3.1.1/npmjx311.tar.gz#b0a696e01db4af87c2b6978453a01e4294951dd915d4770b559cab918a20c127" jxcore_npm


### PR DESCRIPTION
Binaries for old releases are gone (the amazon S3 bucket is no longer
up).

Binaries for 3.1.1 have moved to github: https://github.com/jxcore/jxcore-release/tree/master/0311

Checksums for github assets have been updated.

And the npm package for the dev branch should use latest 3.1.1 instead
of 3.1.0