### PR TITLE
Remove scripty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
 /node_modules
 /nodenv-node-build-jxcore-*.tgz
-/package-lock.json
-/yarn.lock

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,26 @@
+{
+  "name": "@nodenv/node-build-jxcore",
+  "version": "1.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@nodenv/node-build-update-defs": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@nodenv/node-build-update-defs/-/node-build-update-defs-2.8.0.tgz",
+      "integrity": "sha512-gzAFKCo+n83ui1SQCwJHfS9rm3DknC9TEjSdFDKCAZoRQVj3qAIRIP9YQ0QiJpsRJGVoDyB18/AXUTF4Q86oiw==",
+      "dev": true
+    },
+    "bats": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bats/-/bats-1.1.0.tgz",
+      "integrity": "sha512-1pA29OhDByrUtAXX+nmqZxgRgx2y8PvuZzbLJVjd2dpEDVDvz0MjcBMdmIPNq5lC+tG53G+RbeRsbIlv3vw7tg==",
+      "dev": true
+    },
+    "brew-publish": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/brew-publish/-/brew-publish-2.3.1.tgz",
+      "integrity": "sha512-JtitWM9jtnQk2gerUbvpiYJqUPYrvU43Wet1FDm9w81nJJO4BLAeVLUTFWQTQkV7QtE3AVO203R/67NeTMxzVw==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -23,12 +23,12 @@
     "postinstall": "script/postinstall",
     "posttest": "npm run lint",
     "lint": "git ls-files bin script **/*.*sh | xargs shellcheck",
-    "verify-definitions": "scripty",
-    "preversion": "scripty",
+    "verify-definitions": "node_modules/@nodenv/node-build-update-defs/script/verify-definitions",
+    "preversion": "script/preversion",
     "postversion": "npm publish",
     "prepublishOnly": "npm run publish:github && npm run publish:brew",
     "publish:brew": "brew-publish",
-    "publish:github": "scripty"
+    "publish:github": "script/publish/github"
   },
   "devDependencies": {
     "@nodenv/node-build-update-defs": "^2.8.0",

--- a/package.json
+++ b/package.json
@@ -33,12 +33,6 @@
   "devDependencies": {
     "@nodenv/node-build-update-defs": "^2.8.0",
     "bats": "^1.1.0",
-    "brew-publish": "^2.2.0",
-    "scripty": "^2.0.0-0"
-  },
-  "scripty": {
-    "modules": [
-      "@nodenv/node-build-update-defs"
-    ]
+    "brew-publish": "^2.2.0"
   }
 }


### PR DESCRIPTION
I'm a big fan of scripty but we're removing it here.
As a devDependency, it's not possible to rely on scripty to run
pre/post/install scripts. Because of this, some package scripts can
leverage scripty, and some can't; but it's not immediately obvious which
and why. Therefore, I think it's best to remove scripty so it's not
_accidentally_ used in an install-time script.

Scripty should probably be limited to application usage and not
libraries.

(Side benefit, we'll stop getting security notices for all of lodash
which is only a transitive devDep.)